### PR TITLE
Accesspoint domain features

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,6 @@ Functionalities that need to be implemented or repaired:
 
 ( Encryption endpoint needs to be implemeneted. )
 
-🔲 All the AccessPoint [TODO's](https://github.com/Krzysztofz01/AccessPointMap/blob/master/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPoint.cs#L77), all of them are related to the stamp merge functionality.
+✅ All the AccessPoint [TODO's](https://github.com/Krzysztofz01/AccessPointMap/blob/master/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPoint.cs#L77), all of them are related to the stamp merge functionality.
+
+🔲 Migration from .NET5 to .NET6 LTS

--- a/src/AccessPointMap/AccessPointMap.API/AccessPointMap.API.csproj
+++ b/src/AccessPointMap/AccessPointMap.API/AccessPointMap.API.csproj
@@ -11,9 +11,9 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.27" />
     <PackageReference Include="Hangfire.Core" Version="1.7.27" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.12">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AccessPointMap/AccessPointMap.Application.Integration.Aircrackng/AccessPointMap.Application.Integration.Aircrackng.csproj
+++ b/src/AccessPointMap/AccessPointMap.Application.Integration.Aircrackng/AccessPointMap.Application.Integration.Aircrackng.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AccessPointMap/AccessPointMap.Application.Integration.Aircrackng/AircrackngIntegrationService.cs
+++ b/src/AccessPointMap/AccessPointMap.Application.Integration.Aircrackng/AircrackngIntegrationService.cs
@@ -95,6 +95,11 @@ namespace AccessPointMap.Application.Integration.Aircrackng
                     accessPoint.LowLongitude = record.LowLongitude;
                 }
 
+                if (record.LocalTimestamp > accessPoint.LocalTimestamp)
+                {
+                    accessPoint.LocalTimestamp = record.LocalTimestamp;
+                }
+
                 accessPoints[record.Bssid] = accessPoint;
             }
 
@@ -115,7 +120,8 @@ namespace AccessPointMap.Application.Integration.Aircrackng
                 HighSignalLatitude = record.Latitude,
                 HighSignalLongitude = record.Longitude,
                 RawSecurityPayload = record.Security,
-                UserId = _scopeWrapperService.GetUserId()
+                UserId = _scopeWrapperService.GetUserId(),
+                ScanDate = record.LocalTimestamp
             });
 
             await _unitOfWork.AccessPointRepository.Add(accessPoint);
@@ -137,7 +143,8 @@ namespace AccessPointMap.Application.Integration.Aircrackng
                 HighSignalLatitude = record.Latitude,
                 HighSignalLongitude = record.Longitude,
                 RawSecurityPayload = record.Security,
-                UserId = _scopeWrapperService.GetUserId()
+                UserId = _scopeWrapperService.GetUserId(),
+                ScanDate = record.LocalTimestamp
             });
         }
     }

--- a/src/AccessPointMap/AccessPointMap.Application.Integration.Wigle/AccessPointMap.Application.Integration.Wigle.csproj
+++ b/src/AccessPointMap/AccessPointMap.Application.Integration.Wigle/AccessPointMap.Application.Integration.Wigle.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AccessPointMap/AccessPointMap.Application.Integration.Wigle/WigleIntegrationService.cs
+++ b/src/AccessPointMap/AccessPointMap.Application.Integration.Wigle/WigleIntegrationService.cs
@@ -86,7 +86,8 @@ namespace AccessPointMap.Application.Integration.Wigle
                 HighSignalLatitude = record.Latitude,
                 HighSignalLongitude = record.Longitude,
                 RawSecurityPayload = record.AuthMode,
-                UserId = _scopeWrapperService.GetUserId()
+                UserId = _scopeWrapperService.GetUserId(),
+                ScanDate = record.FirstSeen
             });
 
             await _unitOfWork.AccessPointRepository.Add(accessPoint);
@@ -108,7 +109,8 @@ namespace AccessPointMap.Application.Integration.Wigle
                 HighSignalLatitude = record.Latitude,
                 HighSignalLongitude = record.Longitude,
                 RawSecurityPayload = record.AuthMode,
-                UserId = _scopeWrapperService.GetUserId()
+                UserId = _scopeWrapperService.GetUserId(),
+                ScanDate = record.FirstSeen
             });
         }
 
@@ -130,6 +132,11 @@ namespace AccessPointMap.Application.Integration.Wigle
                     accessPoint.LowSignalLevel = record.LowSignalLevel;
                     accessPoint.LowLatitude = record.LowLatitude;
                     accessPoint.LowLongitude = record.LowLongitude;
+                }
+
+                if (record.FirstSeen > accessPoint.FirstSeen)
+                {
+                    accessPoint.FirstSeen = record.FirstSeen;
                 }
             }
 

--- a/src/AccessPointMap/AccessPointMap.Application.Oui.MacTwoVendor/AccessPointMap.Application.Oui.MacTwoVendor.csproj
+++ b/src/AccessPointMap/AccessPointMap.Application.Oui.MacTwoVendor/AccessPointMap.Application.Oui.MacTwoVendor.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.12" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AccessPointMap/AccessPointMap.Application/AccessPointMap.Application.csproj
+++ b/src/AccessPointMap/AccessPointMap.Application/AccessPointMap.Application.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.12" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.13" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.15.0" />
   </ItemGroup>

--- a/src/AccessPointMap/AccessPointMap.Application/AccessPoints/AccessPointService.cs
+++ b/src/AccessPointMap/AccessPointMap.Application/AccessPoints/AccessPointService.cs
@@ -32,7 +32,7 @@ namespace AccessPointMap.Application.AccessPoints
                 case V1.Delete c: await Apply(c.Id, new AccessPointDeleted { Id = c.Id }); break;
                 case V1.Update c: await Apply(c.Id, new AccessPointUpdated { Id = c.Id, Note = c.Note }); break;
                 case V1.ChangeDisplayStatus c: await Apply(c.Id, new AccessPointDisplayStatusChanged { Id = c.Id, Status = c.Status }); break;
-                case V1.MergeWithStamp c: await Apply(c.Id, new AccessPointMergedWithStamp { Id = c.Id, StampId = c.StampId }); break;
+                case V1.MergeWithStamp c: await Apply(c.Id, new AccessPointMergedWithStamp { Id = c.Id, StampId = c.StampId, MergeSsid = c.MergeSsid.Value, MergeLowSignalLevel = c.MergeLowSignalLevel.Value, MergeHighSignalLevel = c.MergeHighSignalLevel.Value, MergeSecurityData = c.MergeSecurityData.Value }); break;
                 case V1.DeleteStamp c: await Apply(c.Id, new AccessPointStampDeleted { Id = c.Id, StampId = c.StampId }); break;
 
                 default: throw new InvalidOperationException("This command is not supported.");
@@ -72,7 +72,8 @@ namespace AccessPointMap.Application.AccessPoints
                         HighSignalLatitude = ap.HighSignalLatitude.Value,
                         HighSignalLongitude = ap.HighSignalLongitude.Value,
                         RawSecurityPayload = ap.RawSecurityPayload,
-                        UserId = userId
+                        UserId = userId,
+                        ScanDate = command.ScanDate.Value
                     });
 
                     await _unitOfWork.Commit();
@@ -91,7 +92,8 @@ namespace AccessPointMap.Application.AccessPoints
                         HighSignalLatitude = ap.HighSignalLatitude.Value,
                         HighSignalLongitude = ap.HighSignalLongitude.Value,
                         RawSecurityPayload = ap.RawSecurityPayload,
-                        UserId = userId
+                        UserId = userId,
+                        ScanDate = command.ScanDate.Value
                     });
 
                     await _unitOfWork.AccessPointRepository.Add(accessPoint);

--- a/src/AccessPointMap/AccessPointMap.Application/AccessPoints/Commands.cs
+++ b/src/AccessPointMap/AccessPointMap.Application/AccessPoints/Commands.cs
@@ -16,6 +16,9 @@ namespace AccessPointMap.Application.AccessPoints
             {
                 [Required]
                 public IEnumerable<Helpers.AccessPointV1> AccessPoints { get; set; }
+
+                [Required]
+                public DateTime? ScanDate { get; set; }
             }
 
             public class Delete : IApplicationCommand<AccessPoint>
@@ -48,6 +51,18 @@ namespace AccessPointMap.Application.AccessPoints
 
                 [Required]
                 public Guid StampId { get; set; }
+
+                [Required]
+                public bool? MergeLowSignalLevel { get; set; }
+                
+                [Required]
+                public bool? MergeHighSignalLevel { get; set; }
+                
+                [Required]
+                public bool? MergeSsid { get; set; }
+                
+                [Required]
+                public bool? MergeSecurityData { get; set; }
             }
 
             public class DeleteStamp : IApplicationCommand<AccessPoint>

--- a/src/AccessPointMap/AccessPointMap.Domain.Test/AccessPointTests.cs
+++ b/src/AccessPointMap/AccessPointMap.Domain.Test/AccessPointTests.cs
@@ -23,7 +23,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = 48.86,
                 HighSignalLongitude = 2.30,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now
             });
         }
 
@@ -42,7 +43,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = 48.86,
                 HighSignalLongitude = 2.30,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now
             });
 
             accesspoint.Apply(new V1.AccessPointDeleted
@@ -69,7 +71,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = 48.86,
                 HighSignalLongitude = 2.30,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now
             });
 
             string noteExpectedBefore = string.Empty;
@@ -100,7 +103,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = 48.86,
                 HighSignalLongitude = 2.30,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now
             });
 
             bool statusExpectedBefore = false;
@@ -131,7 +135,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = 48.86,
                 HighSignalLongitude = 2.30,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now
             });
 
             string manufacturerExpectedBefore = string.Empty;
@@ -162,7 +167,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = 48.86,
                 HighSignalLongitude = 2.30,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now
             });
 
             int updatedLowSignalLevel = -80;
@@ -186,7 +192,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = updatedHighSignalLatitude,
                 HighSignalLongitude = updatedHighSignalLongitude,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now.AddDays(2)
             };
 
             accesspoint.Apply(stampCreationEvent);
@@ -241,7 +248,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = 48.86,
                 HighSignalLongitude = 2.30,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now
             });
 
             int updatedLowSignalLevel = -80;
@@ -265,7 +273,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = updatedHighSignalLatitude,
                 HighSignalLongitude = updatedHighSignalLongitude,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now.AddDays(2)
             };
 
             accesspoint.Apply(stampCreationEvent);
@@ -314,7 +323,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = 48.86,
                 HighSignalLongitude = 2.30,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now
             });
 
             var stampCreationEvent = new V1.AccessPointStampCreated
@@ -328,7 +338,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = 48.86,
                 HighSignalLongitude = 2.30,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now.AddDays(2)
             };
 
             int expectedStampsCollectionCountBefore = 0;
@@ -358,7 +369,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = 48.86,
                 HighSignalLongitude = 2.30,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now
             });
 
             var stampCreationEvent = new V1.AccessPointStampCreated
@@ -372,7 +384,8 @@ namespace AccessPointMap.Domain.Test
                 HighSignalLatitude = 48.86,
                 HighSignalLongitude = 2.30,
                 RawSecurityPayload = "[WPA2][WEP]",
-                UserId = Guid.NewGuid()
+                UserId = Guid.NewGuid(),
+                ScanDate = DateTime.Now.AddDays(2)
             };
 
             int expectedStampsCollectionCountBefore = 0;

--- a/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPoint.cs
+++ b/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPoint.cs
@@ -74,8 +74,6 @@ namespace AccessPointMap.Domain.AccessPoints
             Manufacturer = AccessPointManufacturer.FromString(@event.Manufacturer);
         }
 
-        //TODO: The creation should be defined by scan date and not update date
-        //TODO: More ,,freedom'' in update??
         private void When(V1.AccessPointMergedWithStamp @event)
         {
             var stamp = _stamps
@@ -193,8 +191,8 @@ namespace AccessPointMap.Domain.AccessPoints
                     Frequency = AccessPointFrequency.FromDouble(@event.Frequency),
                     DeviceType = AccessPointDeviceType.FromString(@event.Ssid),
                     ContributorId = AccessPointContributorId.FromGuid(@event.UserId),
-                    CreationTimestamp = AccessPointCreationTimestamp.Now,
-                    VersionTimestamp = AccessPointVersionTimestamp.Now,
+                    CreationTimestamp = AccessPointCreationTimestamp.FromDateTime(@event.ScanDate),
+                    VersionTimestamp = AccessPointVersionTimestamp.FromDateTime(@event.ScanDate),
                     Positioning = AccessPointPositioning.FromGpsAndRssi(
                         @event.LowSignalLevel,
                         @event.LowSignalLatitude,

--- a/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPoint.cs
+++ b/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPoint.cs
@@ -77,8 +77,6 @@ namespace AccessPointMap.Domain.AccessPoints
         //TODO: Separate merge for measurement-dependent and time-dependent data
         //TODO: The creation should be defined by scan date and not update date
         //TODO: Check for default frequency, because of integration inconsistency
-        //TODO: ValueObject helper collections should be static
-        //TODO: Move all constants to one place
         //TODO: More selective merge options
         //TODO: More ,,freedom'' in update??
         private void When(V1.AccessPointMergedWithStamp @event)

--- a/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPointCreationTimestamp.cs
+++ b/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPointCreationTimestamp.cs
@@ -11,6 +11,5 @@ namespace AccessPointMap.Domain.AccessPoints
         public static implicit operator DateTime(AccessPointCreationTimestamp creationTimestamp) => creationTimestamp.Value;
 
         public static AccessPointCreationTimestamp FromDateTime(DateTime date) => new AccessPointCreationTimestamp(date);
-        public static AccessPointCreationTimestamp Now => new AccessPointCreationTimestamp(DateTime.Now);
     }
 }

--- a/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPointDeviceType.cs
+++ b/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPointDeviceType.cs
@@ -1,22 +1,11 @@
 ﻿using AccessPointMap.Domain.Core.Extensions;
 using AccessPointMap.Domain.Core.Models;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace AccessPointMap.Domain.AccessPoints
 {
     public class AccessPointDeviceType : ValueObject<AccessPointDeviceType>
     {
-        private readonly IReadOnlyDictionary<IEnumerable<string>, string> _deviceTypeDictionary = new Dictionary<IEnumerable<string>, string>
-        {
-            { new string[] { "printer", "print", "jet" }, "Printer" },
-            { new string[] { "hotspot" }, "Access point" },
-            { new string[] { "tv", "bravia" }, "Tv" },
-            { new string[] { "cctv", "cam", "iptv", "monitoring" }, "Cctv" },
-            { new string[] { "repeater", "extender" }, "Repeater" },
-            { new string[] { "iot" }, "IoT" }
-        };
-
         private const string _defaultDeviceType = "Unknown";
         public static string DefaultDeviceType => _defaultDeviceType;
 
@@ -31,7 +20,8 @@ namespace AccessPointMap.Domain.AccessPoints
                 return;
             }
 
-            Value = _deviceTypeDictionary
+            //TODO Search keywoard in ssid and not ssid in keywoard
+            Value = Constants.DeviceTypeDictionary
                 .Where(d => d.Key
                     .Any(k => k.Contains(value
                         .Trim()

--- a/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPointSecurity.cs
+++ b/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPointSecurity.cs
@@ -8,15 +8,6 @@ namespace AccessPointMap.Domain.AccessPoints
 {
     public class AccessPointSecurity : ValueObject<AccessPointSecurity>
     {
-        private readonly IReadOnlyCollection<EncryptionType> _encryptionTypes = new List<EncryptionType>
-        {
-            new EncryptionType { Name = "WPA3", IsSecure = true, Priority = 10 },
-            new EncryptionType { Name = "WPA2", IsSecure = true, Priority = 9 },
-            new EncryptionType { Name = "WPA", IsSecure = true, Priority = 8 },
-            new EncryptionType { Name = "WPS", IsSecure = false, Priority = 7 },
-            new EncryptionType { Name = "WEP", IsSecure = false, Priority = 6 }
-        };
-
         public string RawSecurityPayload { get; private set; }
         public string SerializedSecurityPayload { get; private set; }
         
@@ -37,7 +28,7 @@ namespace AccessPointMap.Domain.AccessPoints
 
                 var usedEncryptionTypes = new List<EncryptionType>();
 
-                foreach (var type in _encryptionTypes)
+                foreach (var type in Constants.EncryptionTypes)
                 {
                     if (RawSecurityPayload.Contains(type.Name))
                         usedEncryptionTypes.Add(type);
@@ -59,12 +50,5 @@ namespace AccessPointMap.Domain.AccessPoints
         }
 
         public static AccessPointSecurity FromString(string rawSecurityPayload) => new AccessPointSecurity(rawSecurityPayload);
-    }
-
-    internal class EncryptionType
-    {
-        public string Name { get; init; }
-        public bool IsSecure { get; init; }
-        public int Priority { get; init; }
     }
 }

--- a/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPointStamps/AccessPointStamp.cs
+++ b/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPointStamps/AccessPointStamp.cs
@@ -59,7 +59,7 @@ namespace AccessPointMap.Domain.AccessPoints.AccessPointStamps
                     Frequency = AccessPointFrequency.FromDouble(@event.Frequency),
                     DeviceType = AccessPointDeviceType.FromString(@event.Ssid),
                     ContributorId = AccessPointContributorId.FromGuid(@event.UserId),
-                    CreationTimestamp = AccessPointCreationTimestamp.Now,
+                    CreationTimestamp = AccessPointCreationTimestamp.FromDateTime(@event.ScanDate),
                     Positioning = AccessPointPositioning.FromGpsAndRssi(
                         @event.LowSignalLevel,
                         @event.LowSignalLatitude,

--- a/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPointVersionTimestamp.cs
+++ b/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/AccessPointVersionTimestamp.cs
@@ -11,6 +11,5 @@ namespace AccessPointMap.Domain.AccessPoints
         public static implicit operator DateTime(AccessPointVersionTimestamp modificationTimestamp) => modificationTimestamp.Value;
 
         public static AccessPointVersionTimestamp FromDateTime(DateTime date) => new AccessPointVersionTimestamp(date);
-        public static AccessPointVersionTimestamp Now => new AccessPointVersionTimestamp(DateTime.Now);
     }
 }

--- a/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/Constants.cs
+++ b/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/Constants.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+
+namespace AccessPointMap.Domain.AccessPoints
+{
+    public static class Constants
+    {
+        public static readonly IReadOnlyDictionary<IEnumerable<string>, string> DeviceTypeDictionary = new Dictionary<IEnumerable<string>, string>
+        {
+            { new string[] { "printer", "print", "jet" }, "Printer" },
+            { new string[] { "hotspot", "free" }, "Access point" },
+            { new string[] { "tv", "bravia" }, "Tv" },
+            { new string[] { "cctv", "cam", "iptv", "monitoring" }, "Cctv" },
+            { new string[] { "repeater", "extender" }, "Repeater" },
+            { new string[] { "iot" }, "IoT" }
+        };
+
+        public static readonly IReadOnlyCollection<EncryptionType> EncryptionTypes = new List<EncryptionType>
+        {
+            new EncryptionType { Name = "WPA3", IsSecure = true, Priority = 10 },
+            new EncryptionType { Name = "WPA2", IsSecure = true, Priority = 9 },
+            new EncryptionType { Name = "WPA", IsSecure = true, Priority = 8 },
+            new EncryptionType { Name = "WPS", IsSecure = false, Priority = 7 },
+            new EncryptionType { Name = "WEP", IsSecure = false, Priority = 6 }
+        };
+    }
+
+    public class EncryptionType
+    {
+        public string Name { get; init; }
+        public bool IsSecure { get; init; }
+        public int Priority { get; init; }
+    }
+}

--- a/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/Constants.cs
+++ b/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/Constants.cs
@@ -11,7 +11,8 @@ namespace AccessPointMap.Domain.AccessPoints
             { new string[] { "tv", "bravia" }, "Tv" },
             { new string[] { "cctv", "cam", "iptv", "monitoring" }, "Cctv" },
             { new string[] { "repeater", "extender" }, "Repeater" },
-            { new string[] { "iot" }, "IoT" }
+            { new string[] { "iot" }, "IoT" },
+            { new string[] { "car" }, "Car" }
         };
 
         public static readonly IReadOnlyCollection<EncryptionType> EncryptionTypes = new List<EncryptionType>

--- a/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/Events.cs
+++ b/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/Events.cs
@@ -49,6 +49,10 @@ namespace AccessPointMap.Domain.AccessPoints
             {
                 public Guid Id { get; set; }
                 public Guid StampId { get; set; }
+                public bool MergeLowSignalLevel { get; set; }
+                public bool MergeHighSignalLevel { get; set; }
+                public bool MergeSsid { get; set; }
+                public bool MergeSecurityData { get; set; }
             }
 
             public class AccessPointStampCreated : IEvent

--- a/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/Events.cs
+++ b/src/AccessPointMap/AccessPointMap.Domain/AccessPoints/Events.cs
@@ -20,6 +20,7 @@ namespace AccessPointMap.Domain.AccessPoints
                 public double HighSignalLongitude { get; set; }
                 public string RawSecurityPayload { get; set; }
                 public Guid UserId { get; set; }
+                public DateTime ScanDate { get; set; }
             }
 
             public class AccessPointDeleted : IEvent
@@ -68,6 +69,7 @@ namespace AccessPointMap.Domain.AccessPoints
                 public double HighSignalLongitude { get; set; }
                 public string RawSecurityPayload { get; set; }
                 public Guid UserId { get; set; }
+                public DateTime ScanDate { get; set; }
             }
 
             public class AccessPointStampDeleted : IEvent

--- a/src/AccessPointMap/AccessPointMap.Infrastructure.MySql/AccessPointMap.Infrastructure.MySql.csproj
+++ b/src/AccessPointMap/AccessPointMap.Infrastructure.MySql/AccessPointMap.Infrastructure.MySql.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.12">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Changes:
- More control over stamp merges
- Creation timestamp changed to indicate the scan date
- All accesspoint related constants moved into one place
- Refactored unit tests for changes
- Access point frequency inconsistency handled
- Aircrack-ng integration adjusted to domain changes
- WiGLE integration adjusted to domain changes
- Service layer adjusted to domain changes
- Dependencies version bump