### PR TITLE
Support for cookie dependent auth dropped

### DIFF
--- a/src/AccessPointMap/AccessPointMap.Application/Authentication/AuthenticationService.cs
+++ b/src/AccessPointMap/AccessPointMap.Application/Authentication/AuthenticationService.cs
@@ -110,10 +110,10 @@ namespace AccessPointMap.Application.Authentication
 
         public async Task<Responses.V1.Refresh> Refresh(Requests.V1.Refresh request)
         {
-            if (request.RefrshToken.IsEmpty())
+            if (request.RefreshToken.IsEmpty())
                 throw new InvalidOperationException("Invalid authentication credentials.");
 
-            var refreshTokenHash = _authenticationWrapperService.HashString(request.RefrshToken);
+            var refreshTokenHash = _authenticationWrapperService.HashString(request.RefreshToken);
 
             var identity = await _authenticationDataAccessService.GetUserByRefreshToken(refreshTokenHash);
 

--- a/src/AccessPointMap/AccessPointMap.Application/Authentication/Requests.cs
+++ b/src/AccessPointMap/AccessPointMap.Application/Authentication/Requests.cs
@@ -33,6 +33,8 @@ namespace AccessPointMap.Application.Authentication
 
             public class Logout
             {
+                [Required]
+                public string RefreshToken { get; set; }
             }
 
             public class PasswordReset
@@ -46,6 +48,8 @@ namespace AccessPointMap.Application.Authentication
 
             public class Refresh
             {
+                [Required]
+                public string RefrshToken { get; set; }
             }
         }
     }

--- a/src/AccessPointMap/AccessPointMap.Application/Authentication/Requests.cs
+++ b/src/AccessPointMap/AccessPointMap.Application/Authentication/Requests.cs
@@ -49,7 +49,7 @@ namespace AccessPointMap.Application.Authentication
             public class Refresh
             {
                 [Required]
-                public string RefrshToken { get; set; }
+                public string RefreshToken { get; set; }
             }
         }
     }

--- a/src/AccessPointMap/AccessPointMap.Application/Authentication/Responses.cs
+++ b/src/AccessPointMap/AccessPointMap.Application/Authentication/Responses.cs
@@ -7,11 +7,13 @@
             public class Login
             {
                 public string JsonWebToken { get; set; }
+                public string RefreshToken { get; set; }
             }
 
             public class Refresh
             {
                 public string JsonWebToken { get; set; }
+                public string RefreshToken { get; set; }
             }
         }
     }

--- a/src/AccessPointMap/AccessPointMap.Application/Authorization/ScopeWrapperService.cs
+++ b/src/AccessPointMap/AccessPointMap.Application/Authorization/ScopeWrapperService.cs
@@ -1,10 +1,8 @@
-﻿using AccessPointMap.Application.Settings;
-using AccessPointMap.Domain.Core.Exceptions;
+﻿using AccessPointMap.Domain.Core.Exceptions;
 using AccessPointMap.Domain.Core.Extensions;
 using AccessPointMap.Domain.Identities;
 using AccessPointMap.Infrastructure.Core.Abstraction;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
 using System;
 using System.Linq;
 using System.Security.Claims;
@@ -14,21 +12,11 @@ namespace AccessPointMap.Application.Authorization
     public class ScopeWrapperService : IScopeWrapperService
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly JsonWebTokenSettings _jwtSettings;
-        private readonly SecuritySettings _securitySettings;
 
-        private const string _refreshTokenCookieName = "accesspointmap_refresh_token";
-
-        public ScopeWrapperService(IHttpContextAccessor httpContextAccessor, IOptions<JsonWebTokenSettings> jsonWebTokenSettings, IOptions<SecuritySettings> securitySettings)
+        public ScopeWrapperService(IHttpContextAccessor httpContextAccessor)
         {
             _httpContextAccessor = httpContextAccessor ??
                 throw new ArgumentNullException(nameof(httpContextAccessor));
-
-            _jwtSettings = jsonWebTokenSettings.Value ??
-                throw new ArgumentNullException(nameof(jsonWebTokenSettings)); ;
-
-            _securitySettings = securitySettings.Value ??
-                throw new ArgumentNullException(nameof(securitySettings));
         }
 
         public string GetIpAddress()
@@ -62,21 +50,6 @@ namespace AccessPointMap.Application.Authorization
             if (claimsValue is null) SystemAuthorizationException.Unauthenticated();
 
             return (UserRole)Enum.Parse(typeof(UserRole), claimsValue);
-        }
-
-        public void SetRefreshTokenCookie(string refreshTokenCookieValue)
-        {
-            _httpContextAccessor.HttpContext.Response.Cookies.Append(_refreshTokenCookieName, refreshTokenCookieValue, new CookieOptions
-            {
-                HttpOnly = false,
-                Expires = DateTime.Now.AddDays(_jwtSettings.RefreshTokenExpirationDays),
-                SameSite = (_securitySettings.SecureMode) ? SameSiteMode.Lax : SameSiteMode.None
-            });
-        }
-
-        public string GetRefreshTokenCookie()
-        {
-            return _httpContextAccessor.HttpContext.Request.Cookies[_refreshTokenCookieName];
         }
     }
 }

--- a/src/AccessPointMap/AccessPointMap.Infrastructure.Core/Abstraction/IScopeWrapperService.cs
+++ b/src/AccessPointMap/AccessPointMap.Infrastructure.Core/Abstraction/IScopeWrapperService.cs
@@ -8,7 +8,5 @@ namespace AccessPointMap.Infrastructure.Core.Abstraction
         string GetIpAddress();
         Guid GetUserId();
         UserRole GetUserRole();
-        void SetRefreshTokenCookie(string refreshTokenCookieValue);
-        string GetRefreshTokenCookie();
     }
 }


### PR DESCRIPTION
Refresh tokens are now delivered in response body, for easier client side usage and consistency.